### PR TITLE
Output cost check and Transaction type check fixes

### DIFF
--- a/neo-lux/NeoAPI.cs
+++ b/neo-lux/NeoAPI.cs
@@ -227,13 +227,16 @@ namespace NeoLux
                     throw new NeoException($"Not enough {symbol}");
                 }
 
-                var output = new Transaction.Output()
+                if(cost > 0)
                 {
-                    assetID = assetID,
-                    scriptHash = outputHash,
-                    value = cost
-                };
-                outputs.Add(output);
+                    var output = new Transaction.Output()
+                    {
+                        assetID = assetID,
+                        scriptHash = outputHash,
+                        value = cost
+                    };
+                    outputs.Add(output);
+                }
 
                 if (selected > cost)
                 {

--- a/neo-lux/Transaction.cs
+++ b/neo-lux/Transaction.cs
@@ -85,7 +85,7 @@ namespace NeoLux
             result.Append(num2hexstring(tx.version));
 
             // excluusive data
-            if (tx.version == 0xd1)
+            if (tx.type == 0xd1)
             {
                 result.Append(num2VarInt(tx.script.Length));
                 result.Append(tx.script.ToHexString());


### PR DESCRIPTION
Added cost check for greater than zero in NeoAPI.cs to account for changes disallowing output costs of 0

Fixed use of tx.version instead of tx.type when checking the type in Transaction.cs