### PR TITLE
Fixed bug in NEP5.Transfer where "balanceOf" was being called

### DIFF
--- a/neo-lux/NEP5.cs
+++ b/neo-lux/NEP5.cs
@@ -116,7 +116,7 @@ namespace NeoLux
             BigInteger amount = new BigInteger((ulong)value);
 
             var sender_address_hash = from_key.address.GetScriptHashFromAddress();
-            var response = api.CallContract(from_key, contractHash, "balanceOf", new object[] { sender_address_hash, to_address_hash, amount });
+            var response = api.CallContract(from_key, contractHash, "transfer", new object[] { sender_address_hash, to_address_hash, amount });
             return response;
         }
     }


### PR DESCRIPTION
Fixed bug in NEP5.Transfer where "balanceOf" was being called instead of "transfer" on the smart contract.